### PR TITLE
added drag&drop support

### DIFF
--- a/ArcdpsLogManager/Sections/LogList.cs
+++ b/ArcdpsLogManager/Sections/LogList.cs
@@ -26,6 +26,8 @@ namespace GW2Scratch.ArcdpsLogManager.Sections
 		private GridViewSorter<LogData> sorter;
 		private FilterCollection<LogData> dataStore;
 
+        private bool mouseDown = false;
+
 		public FilterCollection<LogData> DataStore
 		{
 			get => dataStore;
@@ -214,7 +216,30 @@ namespace GW2Scratch.ArcdpsLogManager.Sections
 			sorter.EnableSorting();
 			sorter.SortByDescending(dateColumn);
 
+            gridView.MouseDown += OnGridViewOnMouseDown;
+            gridView.MouseUp += GridViewOnMouseUp;
+            gridView.MouseLeave += GridViewOnMouseLeave;
+
 			return gridView;
 		}
-	}
+
+        private void GridViewOnMouseLeave(object sender, MouseEventArgs e)
+        {
+            if (!mouseDown) return;
+
+            var files = logGridView.SelectedItems.Select(x => new Uri(x.FileInfo.ToString())).ToArray();
+            var dob = new DataObject {Uris = files};
+            DoDragDrop(dob, DragEffects.Copy | DragEffects.Move);
+        }
+
+        private void GridViewOnMouseUp(object sender, MouseEventArgs e)
+        {
+            mouseDown = false;
+        }
+
+        private void OnGridViewOnMouseDown(object sender, MouseEventArgs args)
+        {
+            mouseDown = true;
+        }
+    }
 }


### PR DESCRIPTION
### Added drag and drop support

2 issues arose while testing:

#### picoe/Eto#1322
Multiselect causes the selection to reset when trying to drag out multiple selected logs.
A workaround for that is to use the right mouse button instead of the left.

#### picoe/Eto#1400 **blocking issue**
Paths that need to be escaped are escaped 2 times. This breaks the uri paths.
The current workaround for this is to move the logs folder out of the standard directory under `Documents\Guild Wars 2` and select a path that needs no escaping.
That includes turning off boss and character names in the arcdps settings.
