### PR TITLE
Log Compression Menu Item

### DIFF
--- a/ArcdpsLogManager/Dialogs/CompressDialog.cs
+++ b/ArcdpsLogManager/Dialogs/CompressDialog.cs
@@ -1,0 +1,69 @@
+using System;
+using System.Collections.Generic;
+using Eto.Drawing;
+using Eto.Forms;
+using GW2Scratch.ArcdpsLogManager.Logs;
+using GW2Scratch.ArcdpsLogManager.Logs.Compressing;
+
+namespace GW2Scratch.ArcdpsLogManager.Dialogs
+{
+    public class CompressDialog : Dialog
+    {
+        public CompressDialog(ManagerForm managerForm)
+        {
+            Title = "Compress Logs";
+            DynamicLayout formLayout = new DynamicLayout();
+            Content = formLayout;
+
+            Button closeButton = new Button {Text = "Close"};
+            closeButton.Click += (sender, args) => Close();
+            PositiveButtons.Add(closeButton);
+
+            // Form components
+            Label explanationLabel = new Label {
+                Text = "Compress uncompressed logs to save space."
+            };
+
+			string buttonText = "Compress logs";
+            Button compressLogsButton = new Button {
+				Text = buttonText
+			};
+            compressLogsButton.Click += (sender, args) => {
+				LogCompressor compressor = new LogCompressor();
+
+				compressor.Progress += (object sender, LogCompressorProgressEventArgs args) => {
+					Application.Instance.AsyncInvoke(() => {
+						if (args.current == args.total) {
+							compressLogsButton.Text = buttonText;
+						} else {
+							compressLogsButton.Text = $"{args.current} / {args.total}";
+						}
+					});
+				};
+
+				compressor.Finished += (object sender, EventArgs args) => {
+					managerForm.LogCache?.SaveToFile();
+					managerForm.ReloadLogs();
+				};
+
+                IEnumerable<LogData> uncompressedLogs = compressor.Compress(managerForm.LoadedLogs);
+                
+                foreach (LogData log in uncompressedLogs) {
+                    managerForm.LogCache?.ClearLogDataEntry(log.FileName);
+                }
+            };
+
+            // Form layout
+            formLayout.BeginVertical(new Padding(10), new Size(0, 0));
+            {
+                formLayout.AddRow(explanationLabel);
+            }
+            formLayout.EndVertical();
+            formLayout.BeginVertical(new Padding(10), new Size(5, 5));
+            {
+                formLayout.AddRow(compressLogsButton);
+            }
+            formLayout.EndVertical();
+        }
+    }
+}

--- a/ArcdpsLogManager/Logs/Compressing/LogCompressorProgressEventArgs.cs
+++ b/ArcdpsLogManager/Logs/Compressing/LogCompressorProgressEventArgs.cs
@@ -1,0 +1,15 @@
+using System;
+
+namespace GW2Scratch.ArcdpsLogManager.Logs.Compressing
+{
+	public class LogCompressorProgressEventArgs : EventArgs
+	{
+		public int current;
+		public int total;
+
+		public LogCompressorProgressEventArgs(int current, int total) {
+			this.current = current;
+			this.total = total;
+		}
+	}
+}

--- a/ArcdpsLogManager/Logs/LogCache.cs
+++ b/ArcdpsLogManager/Logs/LogCache.cs
@@ -141,6 +141,14 @@ namespace GW2Scratch.ArcdpsLogManager.Logs
 			}
 		}
 
+		public void ClearLogDataEntry(string filename)
+		{
+			lock (dictionaryLock)
+			{
+				logsByFilename.Remove(filename);
+			}
+		}
+
 		public bool TryGetLogData(FileInfo fileInfo, out LogData data)
 		{
 			return TryGetLogData(fileInfo.FullName, out data);

--- a/ArcdpsLogManager/Logs/LogCompressor.cs
+++ b/ArcdpsLogManager/Logs/LogCompressor.cs
@@ -1,0 +1,88 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Threading.Tasks;
+using GW2Scratch.ArcdpsLogManager.Logs;
+using GW2Scratch.ArcdpsLogManager.Logs.Compressing;
+
+namespace GW2Scratch.ArcdpsLogManager
+{
+    public class LogCompressor
+    {
+        /// <summary>
+        /// Compresses All Uncompressed Logs
+        ///
+        /// return IEnumerable<LogData> List of All Uncompressed Logs
+		/// </summary>
+        public IEnumerable<LogData> Compress(IEnumerable<LogData> logs)
+        {
+            //Collection of logs fullFileName
+            LinkedList<LogData> uncompressedLogs = new LinkedList<LogData>();
+            foreach (LogData data in logs) {
+                if (data.FileInfo.Extension == ".evtc") {
+                    string fileName = data.FileName;
+                    uncompressedLogs.AddLast(data);
+                }
+            }
+
+			int counter = 0;
+			int length = uncompressedLogs.Count;
+			OperatingSystem os = Environment.OSVersion;
+
+			//Async compression using PowerShell for Windows and Bash for Unix
+			Task.Run(() => {
+				using (Process shell = new Process())
+				{
+					shell.StartInfo.RedirectStandardInput = true;
+					shell.StartInfo.RedirectStandardOutput = true;
+					shell.StartInfo.CreateNoWindow = true;
+
+					shell.OutputDataReceived += new DataReceivedEventHandler((sender, e) => {
+						if (!String.IsNullOrEmpty(e.Data) && e.Data == "Log Compressed") {
+							counter++;
+							Progress?.Invoke(this, new LogCompressorProgressEventArgs(counter, length));
+						}
+					});
+
+					switch (os.Platform) {
+						case (PlatformID.Win32NT):
+							shell.StartInfo.FileName = @"C:\windows\system32\windowspowershell\v1.0\powershell.exe";
+							shell.Start();
+							shell.BeginOutputReadLine();
+
+							foreach (LogData data in uncompressedLogs) {
+								string name = data.FileName.Substring(0, data.FileName.Length - data.FileInfo.Extension.Length);
+								shell.StandardInput.WriteLine($"Compress-Archive \"{name}.evtc\" \"{name}.zip\"");
+								shell.StandardInput.WriteLine($"Remove-Item \"{name}.evtc\"");
+								shell.StandardInput.WriteLine($"Move-Item \"{name}.zip\" \"{name}.zevtc\"");
+								shell.StandardInput.WriteLine("Write-Host \"Log Compressed\"");
+							}
+
+							break;
+						case (PlatformID.Unix):
+							shell.StartInfo.FileName = "/bin/bash";
+							shell.Start();
+							shell.BeginOutputReadLine();
+
+							foreach (LogData data in uncompressedLogs) {
+								string name = data.FileName.Substring(0, data.FileName.Length - data.FileInfo.Extension.Length);
+								shell.StandardInput.WriteLine($"zip -m \"{name}.zevtc\" \"{name}.evtc\"");
+								shell.StandardInput.WriteLine("echo \"Log Compressed\"");
+							}
+
+							break;
+					}
+
+					shell.StandardInput.Close();
+					shell.WaitForExit();
+					Finished?.Invoke(this, EventArgs.Empty);
+				}
+			});
+
+            return uncompressedLogs;
+        }
+
+		public event EventHandler<LogCompressorProgressEventArgs> Progress;
+		public event EventHandler Finished;
+    }
+}

--- a/ArcdpsLogManager/ManagerForm.cs
+++ b/ArcdpsLogManager/ManagerForm.cs
@@ -367,6 +367,9 @@ namespace GW2Scratch.ArcdpsLogManager
 				}
 			};
 
+			var compressLogsItem = new ButtonMenuItem {Text = "&Compress logs"};
+			compressLogsItem.Click += (sender, args) => { new CompressDialog(this).ShowModal(); };
+
 			var logCacheMenuItem = new ButtonMenuItem {Text = "&Log cache"};
 			logCacheMenuItem.Click += (sender, args) => { new CacheDialog(this).ShowModal(this); };
 
@@ -406,6 +409,7 @@ namespace GW2Scratch.ArcdpsLogManager
 
 			var dataMenuItem = new ButtonMenuItem {Text = "&Data"};
 			dataMenuItem.Items.Add(updateMenuItem);
+			dataMenuItem.Items.Add(compressLogsItem);
 			dataMenuItem.Items.Add(new SeparatorMenuItem());
 			dataMenuItem.Items.Add(logCacheMenuItem);
 			dataMenuItem.Items.Add(apiDataMenuItem);


### PR DESCRIPTION
Suggested solution to [Issues 107](https://github.com/gw2scratch/evtc/issues/107): "Add a menu item that compresses all uncompressed logs". I would gladly accept any feedback, if there is an issue.