### PR TITLE
Reducing the amount of filesystem calls

### DIFF
--- a/ArcdpsLogManager/Controls/LogDetailPanel.cs
+++ b/ArcdpsLogManager/Controls/LogDetailPanel.cs
@@ -74,7 +74,7 @@ namespace GW2Scratch.ArcdpsLogManager.Controls
 				double seconds = logData.EncounterDuration.TotalSeconds;
 				string duration = $"{(int) seconds / 60:0}m {seconds % 60:0.0}s";
 
-				fileNameButton.Text = logData.FileInfo.Name;
+				fileNameButton.Text = System.IO.Path.GetFileName(logData.FileName);
 
 				resultLabel.Text = $"{result} in {duration}";
 
@@ -269,7 +269,7 @@ namespace GW2Scratch.ArcdpsLogManager.Controls
 				{
 					var processInfo = new ProcessStartInfo()
 					{
-						FileName = logData.FileInfo.DirectoryName,
+						FileName = System.IO.Path.GetDirectoryName(logData.FileName),
 						UseShellExecute = true
 					};
 					Process.Start(processInfo);

--- a/ArcdpsLogManager/Logs/LogCache.cs
+++ b/ArcdpsLogManager/Logs/LogCache.cs
@@ -146,7 +146,7 @@ namespace GW2Scratch.ArcdpsLogManager.Logs
 				logsByFilename.Clear();
 				foreach (var log in logs)
 				{
-					logsByFilename[log.FileInfo.FullName] = log;
+					logsByFilename[log.FileName] = log;
 				}
 
 				return previousCount - LogCount;
@@ -194,7 +194,7 @@ namespace GW2Scratch.ArcdpsLogManager.Logs
 		{
 			lock (dictionaryLock)
 			{
-				logsByFilename[logData.FileInfo.FullName] = logData;
+				logsByFilename[logData.FileName] = logData;
 				ChangedSinceLastSave = true;
 			}
 		}

--- a/ArcdpsLogManager/Logs/LogFinder.cs
+++ b/ArcdpsLogManager/Logs/LogFinder.cs
@@ -24,27 +24,26 @@ namespace GW2Scratch.ArcdpsLogManager.Logs
 
 			return files.Select(file =>
 			{
-				var fileInfo = new FileInfo(file);
-
 				if (logCache != null)
 				{
-					if (logCache.TryGetLogData(fileInfo, out var cachedLog))
+					if (logCache.TryGetLogData(file, out var cachedLog))
 					{
 						return cachedLog;
 					}
 				}
 
-				return new LogData(fileInfo);
+				return new LogData(file);
 			});
 		}
 
+		/// <summary>
+		/// Checks if the file is put into consideration as a evtc log. 
+		/// It will intentionally not check if the file actually exists to reduce filesystem calls.
+		/// </summary>
+		/// <param name="filename">The fullpath to the file to check.</param>
+		/// <returns>Returns <see langword="true"/> if the file can be considered as a evtc log.</returns>
 		public bool IsLikelyEvtcLog(string filename)
 		{
-			if (!File.Exists(filename))
-			{
-				return false;
-			}
-
 			if (filename.EndsWith(".evtc") || filename.EndsWith(".evtc.zip") || filename.EndsWith(".zevtc"))
 			{
 				return true;

--- a/ArcdpsLogManager/ManagerForm.cs
+++ b/ArcdpsLogManager/ManagerForm.cs
@@ -555,7 +555,7 @@ namespace GW2Scratch.ArcdpsLogManager
 						Task.Run(async () =>
 						{
 							await Task.Delay(delay);
-							if (LogFinder.IsLikelyEvtcLog(args.FullPath))
+							if (File.Exists(args.FullPath) && LogFinder.IsLikelyEvtcLog(args.FullPath))
 							{
 								Application.Instance.AsyncInvoke(() => AddNewLog(args.FullPath));
 							}
@@ -566,7 +566,7 @@ namespace GW2Scratch.ArcdpsLogManager
 						Task.Run(async () =>
 						{
 							await Task.Delay(delay);
-							if (LogFinder.IsLikelyEvtcLog(args.FullPath))
+							if (File.Exists(args.FullPath) && LogFinder.IsLikelyEvtcLog(args.FullPath))
 							{
 								Application.Instance.AsyncInvoke(() => AddNewLog(args.FullPath));
 							}
@@ -586,14 +586,14 @@ namespace GW2Scratch.ArcdpsLogManager
 
 		private void AddNewLog(string fullName)
 		{
-			if (logs.Any(x => x.FileInfo.FullName == fullName))
+			if (logs.Any(x => x.FileName == fullName))
 			{
 				return;
 			}
 
 			if (!LogCache.TryGetLogData(fullName, out var log))
 			{
-				log = new LogData(new FileInfo(fullName));
+				log = new LogData(fullName);
 			}
 
 			if (log.ParsingStatus != ParsingStatus.Parsed)

--- a/ArcdpsLogManager/Sections/DebugData.cs
+++ b/ArcdpsLogManager/Sections/DebugData.cs
@@ -64,7 +64,7 @@ namespace GW2Scratch.ArcdpsLogManager.Sections
 				browserButton.Click += (sender, args) =>
 				{
 					var browserForm = new InspectorForm();
-					browserForm.SelectLog(logData.FileInfo.FullName);
+					browserForm.SelectLog(logData.FileName);
 					browserForm.Show();
 				};
 

--- a/ArcdpsLogManager/Sections/GameDataGathering.cs
+++ b/ArcdpsLogManager/Sections/GameDataGathering.cs
@@ -369,7 +369,7 @@ namespace GW2Scratch.ArcdpsLogManager.Sections
 					Log processedLog;
 					try
 					{
-						var parsedLog = Parser.ParseLog(log.FileInfo.FullName);
+						var parsedLog = Parser.ParseLog(log.FileName);
 						processedLog = Processor.ProcessLog(parsedLog);
 					}
 					catch


### PR DESCRIPTION
This PR solves #135 and reduces the filesystem calls overall.
Previously for every log the manager accessed the file on the filesystem which resulted in a long first startup time.  
If the manager was closed and reopened the startup time were really small due the caching on OS-Level. This also hid other accesses like `File.Exists` which had the same effect.
With this PR the `FileInfo` in `LogData` will be created on demand and then cached for the lifetime of the application. All references to the `FileInfo` were checked and got removed where it wasn't necessary to actually access the filesystem.