### PR TITLE
Fix for API Bug in guilds

### DIFF
--- a/ArcdpsLogManager/Processing/ApiProcessor.cs
+++ b/ArcdpsLogManager/Processing/ApiProcessor.cs
@@ -50,6 +50,12 @@ namespace GW2Scratch.ArcdpsLogManager.Processing
 					notFound = true;
 					retry = false;
 				}
+				catch (ServerErrorException)
+				{
+					// Currently a bug in the gw2 api. It is throwing "unknown error" for not existent guilds
+					notFound = true;
+					retry = false;
+				}
 			} while (retry);
 
 			if (guild != null)


### PR DESCRIPTION
There is currently an API Bug which returns an unknown error when trying to get information about a missing guild.
This PR adds a catch for this case, so it doesnt show a error dialog and continues to load all remaining guilds.