### PR TITLE
Keep a clean home

### DIFF
--- a/.github/workflows/release-manager.yml
+++ b/.github/workflows/release-manager.yml
@@ -32,7 +32,7 @@ jobs:
     - name: Package Log Manager (Linux, GTK)
       run: dotnet publish ArcdpsLogManager.Gtk --configuration Release -r linux-x64 --self-contained=false -p:PublishSingleFile=true -p:IncludeNativeLibrariesForSelfExtract=true -p:IncludeAllContentForSelfExtract=true -o artifacts/manager/linux64/
     - name: Package Log Manager (Linux, GTK, self-contained)
-      run: dotnet publish ArcdpsLogManager.Gtk --configuration Release -r linux-x64 --self-contained=true -p:PublishSingleFile=true -p:IncludeNativeLibrariesForSelfExtract=true -p:IncludeAllContentForSelfExtract=true -o artifacts/manager/linux64-sc/
+      run: dotnet publish ArcdpsLogManager.Gtk --configuration Release -r linux-x64 --self-contained=true -p:PublishSingleFile=true -p:IncludeNativeLibrariesForSelfExtract=false -p:IncludeAllContentForSelfExtract=true -o artifacts/manager/linux64-sc/
     - name: Prettify executable filenames
       run: |
           mv artifacts/manager/win64/GW2Scratch.ArcdpsLogManager.Wpf.exe artifacts/manager/win64/ArcdpsLogManager.exe


### PR DESCRIPTION
Hi Sejsel, thank you for creating the log manager and for distributing the self-contained Linux version.

I have noticed that the `~/.net/ArcdpsLogManager` directory is re-created every time I launch your tool. This bothers me a little bit, since I like to keep my home directory clean. I've found that changing `IncludeAllContentForSelfExtract` from `true` to `false` for the build leads to this directory not being created and the application still working just fine. 

I have no idea why you chose to enable that option. I also don't know much about what this does, but my understanding is that this option makes sure that *everything* the application might need is included. Therefore I checked if disabling it removes anything important from the binary. I found that it only flips 1 bit, presumably the bit responsible for the extraction.
```
$ diff <(xxd GW2Scratch.ArcdpsLogManager.Gtk.true) <(xxd GW2Scratch.ArcdpsLogManager.Gtk.false)                                                                                                          ~/tmp/test
4670433c4670433
< 04743e00: 0000 0100 0000 0000 0000 40b7 a400 0000  ..........@.....
---
> 04743e00: 0000 0000 0000 0000 0000 40b7 a400 0000  ..........@.....
```
So my guess is that this change has no negative consequences.