### PR TITLE
Manager: Corrected log duration to display 1m 00.0s instead of 0m 60.0s

### DIFF
--- a/ArcdpsLogManager/Sections/LogList.cs
+++ b/ArcdpsLogManager/Sections/LogList.cs
@@ -324,8 +324,20 @@ namespace GW2Scratch.ArcdpsLogManager.Sections
 							return "?";
 						}
 
-						var seconds = x.EncounterDuration.TotalSeconds;
-						return $"{(int) seconds / 60:0}m {seconds % 60:00.0}s";
+						var separator = CultureInfo.CurrentCulture.NumberFormat.NumberDecimalSeparator;
+						var totalSeconds = x.EncounterDuration.TotalSeconds;
+						var minutes = (int)totalSeconds / 60;
+						var seconds = (int)totalSeconds % 60;
+						var milliseconds = (int)((totalSeconds - Math.Floor(totalSeconds)) * 1000);
+
+						if (minutes > 60)
+						{
+							var hours = minutes / 60;
+							minutes -= hours * 60;
+							return $"{hours}h {minutes:0}m {seconds}{separator}{milliseconds.ToString()[0]}s";
+						}
+
+						return $"{minutes:0}m {seconds}{separator}{milliseconds.ToString()[0]}s";
 					})
 				}
 			};


### PR DESCRIPTION
Fixes #146 and additionally added hours to the display for logs above 60 minutes
![7244](https://github.com/gw2scratch/evtc/assets/23245218/d80c2bcd-678b-4366-9bae-febde7563c59)
