### PR TITLE
MissileEffect and GadgetCapture events

### DIFF
--- a/ArcdpsLogManager/CHANGELOG.md
+++ b/ArcdpsLogManager/CHANGELOG.md
@@ -32,11 +32,16 @@ This is the full changelog of the arcdps Log Manager.
 - Added StealthChange events
 - Added GadgetAnimation events
 - Added GadgetName events
+- Added MissileEffect events
+- Added GadgetCaptureOutlineShow events
+- Added GadgetCaptureSplitPercent events
+- Added GadgetCaptureOutlineHide events
 - Added Transformation GUIDs via CONTENTLOCAL_TRANSFORMATION
 - Updated Activation and Result enums for Skills
 - Updated BuffRemove enum for Buffs
 - Updated FriendOrFoe enum
 - Added AnimationStart, AnimationEnd, Moving and VisibilityState enums for related events
+- Added GadgetCapture enum
 
 #### Log Manager notes
 - Fixed Statistics/Specializations tab not displaying VoE elite specializations count

--- a/ArcdpsLogManager/CHANGELOG.md
+++ b/ArcdpsLogManager/CHANGELOG.md
@@ -36,6 +36,7 @@ This is the full changelog of the arcdps Log Manager.
 - Added GadgetCaptureOutlineShow events
 - Added GadgetCaptureSplitPercent events
 - Added GadgetCaptureOutlineHide events
+- Added GadgetCaptureOutlinePoint events
 - Added Transformation GUIDs via CONTENTLOCAL_TRANSFORMATION
 - Updated Activation and Result enums for Skills
 - Updated BuffRemove enum for Buffs

--- a/EVTCAnalytics/Events/AgentEvents.cs
+++ b/EVTCAnalytics/Events/AgentEvents.cs
@@ -508,6 +508,9 @@ namespace GW2Scratch.EVTCAnalytics.Events
 	/// <summary>
 	/// Agent visibility state change.
 	/// </summary>
+	/// <remarks>
+	/// Introduced in 20260527
+	/// </remarks>
 	public class AgentStealthChangeEvent(long time, Agent agent, ulong state) : AgentEvent(time, agent)
 	{
 		/// <summary>
@@ -519,6 +522,9 @@ namespace GW2Scratch.EVTCAnalytics.Events
 	/// <summary>
 	/// Player model animation.
 	/// </summary>
+	/// <remarks>
+	/// Introduced in 20260530
+	/// </remarks>
 	public class AgentGadgetAnimationEvent(long time, Agent agent, ulong token) : AgentEvent(time, agent)
 	{
 		public ulong Token { get; } = token;
@@ -527,6 +533,9 @@ namespace GW2Scratch.EVTCAnalytics.Events
 	/// <summary>
 	/// Gadget name visibility state change.
 	/// </summary>
+	/// <remarks>
+	/// Introduced in 20260530
+	/// </remarks>
 	public class AgentGadgetNameEvent(long time, Agent agent, ulong state) : AgentEvent(time, agent)
 	{
 		/// <summary>

--- a/EVTCAnalytics/Events/EffectEvents.cs
+++ b/EVTCAnalytics/Events/EffectEvents.cs
@@ -143,4 +143,31 @@ namespace GW2Scratch.EVTCAnalytics.Events
 		/// </summary>
 		public uint TrackableId { get; } = trackableId;
 	}
+
+	/// <summary>
+	/// Missile effect events.
+	/// </summary>
+	/// <remarks>
+	/// Introduced in EVTC20260610.
+	/// </remarks>
+	public class MissileEffectEvent(
+		long time,
+		Agent agent,
+		uint effectId,
+		int duration,
+		uint trackableId) : AgentEvent(time, agent)
+	{
+		/// <summary>
+		/// Effect Id.
+		/// </summary>
+		public uint EffectId { get; } = effectId;
+		/// <summary>
+		/// Duration of th effect.
+		/// </summary>
+		public int Duration { get; } = duration;
+		/// <summary>
+		/// Trackable id of the effect.
+		/// </summary>
+		public uint TrackableId { get; } = trackableId;
+	}
 }

--- a/EVTCAnalytics/Events/GadgetCaptureEvent.cs
+++ b/EVTCAnalytics/Events/GadgetCaptureEvent.cs
@@ -31,12 +31,12 @@ namespace GW2Scratch.EVTCAnalytics.Events
 	/// <remarks>
 	/// Introduced in EVTC20260610.
 	/// </remarks>
-	public class GadgetCaptureSplitPercentEvent(long time, Agent agent, int percentage, byte cappingFrom, byte cappingBy) : GadgetCaptureEvent(time, agent)
+	public class GadgetCaptureSplitPercentEvent(long time, Agent agent, float percentage, byte cappingFrom, byte cappingBy) : GadgetCaptureEvent(time, agent)
 	{
 		/// <summary>
 		/// Capture percentage.
 		/// </summary>
-		public int Percentage { get; } = percentage;
+		public float Percentage { get; } = percentage;
 		/// <summary>
 		/// Being captured from [color id number].
 		/// </summary>
@@ -56,5 +56,27 @@ namespace GW2Scratch.EVTCAnalytics.Events
 	public class GadgetCaptureOutlineHideEvent(long time, Agent agent) : GadgetCaptureEvent(time, agent)
 	{
 
+	}
+
+	/// <summary>
+	/// Outline point event. There will be one event for each point of the outline.
+	/// </summary>
+	/// <remarks>
+	/// Introduced in EVTC20260612.
+	/// </remarks>
+	public class GadgetCaptureOutlinePointEvent(long time, Agent agent, int pointIndex, float[] position, uint pointCount) : GadgetCaptureEvent(time, agent)
+	{
+		/// <summary>
+		/// The index of the point.
+		/// </summary>
+		public int PointIndex { get; } = pointIndex;
+		/// <summary>
+		/// Position of the point of the outline.
+		/// </summary>
+		public float[] Position { get; } = position;
+		/// <summary>
+		/// The number of points of the capture outline.
+		/// </summary>
+		public uint PointCount { get; } = pointCount;
 	}
 }

--- a/EVTCAnalytics/Events/GadgetCaptureEvent.cs
+++ b/EVTCAnalytics/Events/GadgetCaptureEvent.cs
@@ -1,0 +1,60 @@
+﻿using GW2Scratch.EVTCAnalytics.Model.Agents;
+using GW2Scratch.EVTCAnalytics.Parsed.Enums;
+
+namespace GW2Scratch.EVTCAnalytics.Events
+{
+	/// <summary>
+	/// Gadget capture event wrapper.
+	/// </summary>
+	public class GadgetCaptureEvent(long time, Agent agent) : AgentEvent(time, agent)
+	{
+
+	}
+
+	/// <summary>
+	/// Capture outline is shown.
+	/// </summary>
+	/// <remarks>
+	/// Introduced in EVTC20260610.
+	/// </remarks>
+	public class GadgetCaptureOutlineShowEvent(long time, Agent agent, byte color) : GadgetCaptureEvent(time, agent)
+	{
+		/// <summary>
+		/// Color of the circle: white, red, blue, green.
+		/// </summary>
+		public GadgetCapture Color { get; } = (GadgetCapture)color;
+	}
+
+	/// <summary>
+	/// Capture percentage update.
+	/// </summary>
+	/// <remarks>
+	/// Introduced in EVTC20260610.
+	/// </remarks>
+	public class GadgetCaptureSplitPercentEvent(long time, Agent agent, int percentage, byte cappingFrom, byte cappingBy) : GadgetCaptureEvent(time, agent)
+	{
+		/// <summary>
+		/// Capture percentage.
+		/// </summary>
+		public int Percentage { get; } = percentage;
+		/// <summary>
+		/// Being captured from [color id number].
+		/// </summary>
+		public GadgetCapture CappingFrom { get; } = (GadgetCapture)cappingFrom;
+		/// <summary>
+		/// Capturing by [color id number].
+		/// </summary>
+		public GadgetCapture CappingBy { get; } = (GadgetCapture)cappingBy;
+	}
+
+	/// <summary>
+	/// Capture outline is hidden.
+	/// </summary>
+	/// <remarks>
+	/// Introduced in EVTC20260610.
+	/// </remarks>
+	public class GadgetCaptureOutlineHideEvent(long time, Agent agent) : GadgetCaptureEvent(time, agent)
+	{
+
+	}
+}

--- a/EVTCAnalytics/Parsed/Enums/GadgetCapture.cs
+++ b/EVTCAnalytics/Parsed/Enums/GadgetCapture.cs
@@ -1,0 +1,10 @@
+﻿namespace GW2Scratch.EVTCAnalytics.Parsed.Enums
+{
+	public enum GadgetCapture : byte
+	{
+		White = 0,
+		Red = 1,
+		Blue = 2,
+		Green = 3,
+	}
+}

--- a/EVTCAnalytics/Parsed/Enums/StateChange.cs
+++ b/EVTCAnalytics/Parsed/Enums/StateChange.cs
@@ -84,5 +84,9 @@
 		StealthChange = 76, // Added 20260527
 		GadgetAnimation = 77, // Added 20260530
 		GadgetName = 78, // Added 20260530
+		MissileEffect = 79, // Added 20260610
+		GadgetCaptureOutlineShow = 80, // Added 20260610
+		GadgetCaptureSplitPercent = 81, // Added 20260610
+		GadgetCaptureOutlineHide = 82, // Added 20260610
 	};
 }

--- a/EVTCAnalytics/Parsed/Enums/StateChange.cs
+++ b/EVTCAnalytics/Parsed/Enums/StateChange.cs
@@ -88,5 +88,6 @@
 		GadgetCaptureOutlineShow = 80, // Added 20260610
 		GadgetCaptureSplitPercent = 81, // Added 20260610
 		GadgetCaptureOutlineHide = 82, // Added 20260610
+		GadgetCaptureOutlinePoint = 83, // Added 20260612
 	};
 }

--- a/EVTCAnalytics/Parsing/CombatItemFilters.cs
+++ b/EVTCAnalytics/Parsing/CombatItemFilters.cs
@@ -315,6 +315,7 @@ public class CombatItemFilters : ICombatItemFilters
 		if (eventType == typeof(GadgetCaptureOutlineShowEvent)) return [StateChange.GadgetCaptureOutlineShow];
 		if (eventType == typeof(GadgetCaptureSplitPercentEvent)) return [StateChange.GadgetCaptureSplitPercent];
 		if (eventType == typeof(GadgetCaptureOutlineHideEvent)) return [StateChange.GadgetCaptureOutlineHide];
+		if (eventType == typeof(GadgetCaptureOutlinePointEvent)) return [StateChange.GadgetCaptureOutlinePoint];
 
 		// The unknown event can come from any state change, including not yet implemented ones,
 		// so we need to return all of them.
@@ -432,6 +433,7 @@ public class CombatItemFilters : ICombatItemFilters
 		if (eventType == typeof(GadgetCaptureOutlineShowEvent)) return false;
 		if (eventType == typeof(GadgetCaptureSplitPercentEvent)) return false;
 		if (eventType == typeof(GadgetCaptureOutlineHideEvent)) return false;
+		if (eventType == typeof(GadgetCaptureOutlinePointEvent)) return false;
 
 		// The unknown event can come from anything
 		if (eventType == typeof(UnknownEvent)) return true;
@@ -547,6 +549,7 @@ public class CombatItemFilters : ICombatItemFilters
 		if (eventType == typeof(GadgetCaptureOutlineShowEvent)) return false;
 		if (eventType == typeof(GadgetCaptureSplitPercentEvent)) return false;
 		if (eventType == typeof(GadgetCaptureOutlineHideEvent)) return false;
+		if (eventType == typeof(GadgetCaptureOutlinePointEvent)) return false;
 
 		// The unknown event can come from anything
 		if (eventType == typeof(UnknownEvent)) return true;
@@ -662,6 +665,7 @@ public class CombatItemFilters : ICombatItemFilters
 		if (eventType == typeof(GadgetCaptureOutlineShowEvent)) return [];
 		if (eventType == typeof(GadgetCaptureSplitPercentEvent)) return [];
 		if (eventType == typeof(GadgetCaptureOutlineHideEvent)) return [];
+		if (eventType == typeof(GadgetCaptureOutlinePointEvent)) return [];
 
 		// The unknown event can come from any result, including not yet implemented ones,
 		// so we need to return all of them.
@@ -769,6 +773,7 @@ public class CombatItemFilters : ICombatItemFilters
 			StateChange.GadgetCaptureOutlineShow => false,
 			StateChange.GadgetCaptureSplitPercent => false,
 			StateChange.GadgetCaptureOutlineHide => false,
+			StateChange.GadgetCaptureOutlinePoint => false,
 			_ => throw new ArgumentOutOfRangeException(nameof(stateChange), stateChange, null)
 		};
 	}

--- a/EVTCAnalytics/Parsing/CombatItemFilters.cs
+++ b/EVTCAnalytics/Parsing/CombatItemFilters.cs
@@ -257,13 +257,14 @@ public class CombatItemFilters : ICombatItemFilters
 		if (eventType == typeof(MissileEvent)) return [];
 		if (eventType == typeof(MissileCreateEvent)) return [StateChange.MissileCreate];
 		if (eventType == typeof(MissileLaunchEvent)) return [StateChange.MissileLaunch];
-		if (eventType == typeof(MissileRemoveEvent)) return [StateChange.MissileRemove];
+		if (eventType == typeof(MissileRemoveEvent)) return [StateChange.MissileRemove];		
 
 		if (eventType == typeof(SplitEffectEvent)) return [];
 		if (eventType == typeof(EffectGroundCreateEvent)) return [StateChange.EffectGroundCreate];
 		if (eventType == typeof(EffectGroundRemoveEvent)) return [StateChange.EffectGroundRemove];
 		if (eventType == typeof(EffectAgentCreateEvent)) return [StateChange.EffectAgentCreate];
 		if (eventType == typeof(EffectAgentRemoveEvent)) return [StateChange.EffectAgentRemove];
+		if (eventType == typeof(MissileEffectEvent)) return [StateChange.MissileEffect];
 
 		if (eventType == typeof(BuffEvent)) return [];
 		if (eventType == typeof(BuffRemoveEvent)) return [];
@@ -309,6 +310,11 @@ public class CombatItemFilters : ICombatItemFilters
 		if (eventType == typeof(SquadGroundMarkerEvent)) return [];
 		if (eventType == typeof(SquadGroundMarkerPlaceEvent)) return [StateChange.SquadMarker];
 		if (eventType == typeof(SquadGroundMarkerRemoveEvent)) return [StateChange.SquadMarker];
+
+		if (eventType == typeof(GadgetCaptureEvent)) return [];
+		if (eventType == typeof(GadgetCaptureOutlineShowEvent)) return [StateChange.GadgetCaptureOutlineShow];
+		if (eventType == typeof(GadgetCaptureSplitPercentEvent)) return [StateChange.GadgetCaptureSplitPercent];
+		if (eventType == typeof(GadgetCaptureOutlineHideEvent)) return [StateChange.GadgetCaptureOutlineHide];
 
 		// The unknown event can come from any state change, including not yet implemented ones,
 		// so we need to return all of them.
@@ -375,6 +381,7 @@ public class CombatItemFilters : ICombatItemFilters
 		if (eventType == typeof(EffectGroundRemoveEvent)) return false;
 		if (eventType == typeof(EffectAgentCreateEvent)) return false;
 		if (eventType == typeof(EffectAgentRemoveEvent)) return false;
+		if (eventType == typeof(MissileEffectEvent)) return false;
 
 		if (eventType == typeof(BuffEvent)) return false;
 		if (eventType == typeof(BuffRemoveEvent)) return false;
@@ -420,6 +427,11 @@ public class CombatItemFilters : ICombatItemFilters
 		if (eventType == typeof(SquadGroundMarkerEvent)) return false;
 		if (eventType == typeof(SquadGroundMarkerPlaceEvent)) return false;
 		if (eventType == typeof(SquadGroundMarkerRemoveEvent)) return false;
+
+		if (eventType == typeof(GadgetCaptureEvent)) return false;
+		if (eventType == typeof(GadgetCaptureOutlineShowEvent)) return false;
+		if (eventType == typeof(GadgetCaptureSplitPercentEvent)) return false;
+		if (eventType == typeof(GadgetCaptureOutlineHideEvent)) return false;
 
 		// The unknown event can come from anything
 		if (eventType == typeof(UnknownEvent)) return true;
@@ -484,6 +496,7 @@ public class CombatItemFilters : ICombatItemFilters
 		if (eventType == typeof(EffectGroundRemoveEvent)) return false;
 		if (eventType == typeof(EffectAgentCreateEvent)) return false;
 		if (eventType == typeof(EffectAgentRemoveEvent)) return false;
+		if (eventType == typeof(MissileEffectEvent)) return false;
 
 		if (eventType == typeof(BuffEvent)) return false;
 		if (eventType == typeof(BuffRemoveEvent)) return false;
@@ -529,6 +542,11 @@ public class CombatItemFilters : ICombatItemFilters
 		if (eventType == typeof(SquadGroundMarkerEvent)) return false;
 		if (eventType == typeof(SquadGroundMarkerPlaceEvent)) return false;
 		if (eventType == typeof(SquadGroundMarkerRemoveEvent)) return false;
+
+		if (eventType == typeof(GadgetCaptureEvent)) return false;
+		if (eventType == typeof(GadgetCaptureOutlineShowEvent)) return false;
+		if (eventType == typeof(GadgetCaptureSplitPercentEvent)) return false;
+		if (eventType == typeof(GadgetCaptureOutlineHideEvent)) return false;
 
 		// The unknown event can come from anything
 		if (eventType == typeof(UnknownEvent)) return true;
@@ -593,6 +611,7 @@ public class CombatItemFilters : ICombatItemFilters
 		if (eventType == typeof(EffectGroundRemoveEvent)) return [];
 		if (eventType == typeof(EffectAgentCreateEvent)) return [];
 		if (eventType == typeof(EffectAgentRemoveEvent)) return [];
+		if (eventType == typeof(MissileEffectEvent)) return [];
 
 		if (eventType == typeof(BuffEvent)) return [];
 		if (eventType == typeof(BuffRemoveEvent)) return [];
@@ -638,6 +657,11 @@ public class CombatItemFilters : ICombatItemFilters
 		if (eventType == typeof(SquadGroundMarkerEvent)) return [];
 		if (eventType == typeof(SquadGroundMarkerPlaceEvent)) return [];
 		if (eventType == typeof(SquadGroundMarkerRemoveEvent)) return [];
+
+		if (eventType == typeof(GadgetCaptureEvent)) return [];
+		if (eventType == typeof(GadgetCaptureOutlineShowEvent)) return [];
+		if (eventType == typeof(GadgetCaptureSplitPercentEvent)) return [];
+		if (eventType == typeof(GadgetCaptureOutlineHideEvent)) return [];
 
 		// The unknown event can come from any result, including not yet implemented ones,
 		// so we need to return all of them.
@@ -741,6 +765,10 @@ public class CombatItemFilters : ICombatItemFilters
 			StateChange.StealthChange => false,
 			StateChange.GadgetAnimation => false,
 			StateChange.GadgetName => false,
+			StateChange.MissileEffect => false,
+			StateChange.GadgetCaptureOutlineShow => false,
+			StateChange.GadgetCaptureSplitPercent => false,
+			StateChange.GadgetCaptureOutlineHide => false,
 			_ => throw new ArgumentOutOfRangeException(nameof(stateChange), stateChange, null)
 		};
 	}

--- a/EVTCAnalytics/Processing/LogProcessor.cs
+++ b/EVTCAnalytics/Processing/LogProcessor.cs
@@ -1909,19 +1909,34 @@ namespace GW2Scratch.EVTCAnalytics.Processing
 					case StateChange.GadgetCaptureSplitPercent:
 					{
 						// src_agent: relates to agent
-						// value: *(float*)&ev->value percent
+						// value: *(float*)&ev->value percent (1.0 - 0.0)
 						// buff: wrbg capping from
 						// result: wrbg capping by
 
 						// Note by deltaconnected on Discord: value is the float without any conversion or lower-precision-inting
 
-						return new GadgetCaptureSplitPercentEvent(item.Time, GetAgentByAddress(item.SrcAgent), item.Value, item.Buff, (byte)item.Result);
+						float percentage = BitConverter.Int32BitsToSingle(item.Value);
+
+						return new GadgetCaptureSplitPercentEvent(item.Time, GetAgentByAddress(item.SrcAgent), percentage, item.Buff, (byte)item.Result);
 					}
 					case StateChange.GadgetCaptureOutlineHide:
 					{
 						// src_agent: relates to agent
 
 						return new GadgetCaptureOutlineHideEvent(item.Time, GetAgentByAddress(item.SrcAgent));
+					}
+					case StateChange.GadgetCaptureOutlinePoint:
+					{
+						// src_agent: relates to agent
+						// dst_agent: point index
+						// value: *(float*)&ev->value x
+						// buff_dmg: *(float*)&ev->buff_dmg y
+						// overstack_value: point count for this agent. if count is 1, shape is a circle around agent with radius x
+
+						float x = BitConverter.Int32BitsToSingle(item.Value);
+						float y = BitConverter.Int32BitsToSingle(item.BuffDmg);
+
+						return new GadgetCaptureOutlinePointEvent(item.Time, GetAgentByAddress(item.SrcAgent), (int)item.DstAgent, [x, y], item.OverstackValue);
 					}
 					default:
 						return new UnknownEvent(item.Time, item);

--- a/EVTCAnalytics/Processing/LogProcessor.cs
+++ b/EVTCAnalytics/Processing/LogProcessor.cs
@@ -1890,6 +1890,39 @@ namespace GW2Scratch.EVTCAnalytics.Processing
 
 						return new AgentGadgetNameEvent(item.Time, GetAgentByAddress(item.SrcAgent), item.DstAgent);
 					}
+					case StateChange.MissileEffect:
+					{
+						// dst_agent: owner of missile
+						// skillid: effect id
+						// value: *(uint32_t*)&value duration
+						// pad61: (uint32_t*)&pad61 is uint32[1], trackable id
+
+						return new MissileEffectEvent(item.Time, GetAgentByAddress(item.DstAgent), item.SkillId, item.Value, item.Padding);
+					}
+					case StateChange.GadgetCaptureOutlineShow:
+					{
+						// src_agent: relates to agent
+						// buff: wrbg colour
+
+						return new GadgetCaptureOutlineShowEvent(item.Time, GetAgentByAddress(item.SrcAgent), item.Buff);
+					}
+					case StateChange.GadgetCaptureSplitPercent:
+					{
+						// src_agent: relates to agent
+						// value: *(float*)&ev->value percent
+						// buff: wrbg capping from
+						// result: wrbg capping by
+
+						// Note by deltaconnected on Discord: value is the float without any conversion or lower-precision-inting
+
+						return new GadgetCaptureSplitPercentEvent(item.Time, GetAgentByAddress(item.SrcAgent), item.Value, item.Buff, (byte)item.Result);
+					}
+					case StateChange.GadgetCaptureOutlineHide:
+					{
+						// src_agent: relates to agent
+
+						return new GadgetCaptureOutlineHideEvent(item.Time, GetAgentByAddress(item.SrcAgent));
+					}
 					default:
 						return new UnknownEvent(item.Time, item);
 				}


### PR DESCRIPTION
# Added
- StateChange.MissileEffect
- StateChange.GadgetCaptureOutlineShow
- StateChange.GadgetCaptureSplitPercent
- StateChange.GadgetCaptureOutlineHide
- StateChange.GadgetCaptureOutlinePoint
- GadgetCapture enum

Also added some evtc date documentation for other State Changes that were missing
