### PR TITLE
Generate a skill with UNKNOWN name for logs with empty skill list

### DIFF
--- a/EVTCAnalytics/Processing/LogProcessor.cs
+++ b/EVTCAnalytics/Processing/LogProcessor.cs
@@ -1048,7 +1048,7 @@ namespace GW2Scratch.EVTCAnalytics.Processing
 					return skill;
 				}
 
-				return null;
+				return new Skill(id, "UNKNOWN");
 			}
 			
 			Skill GetSkillByIdOrAdd(uint id)


### PR DESCRIPTION
This fixes log parsing for broken logs without a skills list.